### PR TITLE
Remove unused A and D key prevention

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -82,7 +82,7 @@ function App() {
   // Handle pointer lock and mouse/keyboard input
   useEffect(() => {
     const handleKeyDown = (e) => {
-      if (['KeyA', 'KeyD', 'KeyW', 'KeyS', 'Space', 'Escape'].includes(e.code)) {
+      if (['KeyW', 'KeyS', 'Space', 'Escape'].includes(e.code)) {
         e.preventDefault();
       }
       


### PR DESCRIPTION
## Summary
- Remove KeyA and KeyD from keydown prevention list since they have no movement logic

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1eba2fa20832abe1fea7a2e6794b2