### PR TITLE
refactor: centralize layout metrics

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,7 +3,41 @@ import { Ship } from './components/Ship.js';
 import { Asteroid } from './components/Asteroid.js';
 import { Bullet } from './components/Bullet.js';
 import { checkCollision, wrapPosition } from './utils/collision.js';
-import { CANVAS_WIDTH, CANVAS_HEIGHT, BULLET_FIRE_RATE, STAR_COUNT, STAR_MIN_BRIGHTNESS, STAR_MAX_BRIGHTNESS, INITIAL_ASTEROID_COUNT, MAX_BULLETS, CONTINUOUS_FIRE_RATE, CROSSHAIR_SIZE, MOUSE_OFFSET, SCORE_PER_ASTEROID, INITIAL_LIVES, STAR_LARGE_THRESHOLD, STAR_MEDIUM_THRESHOLD, WORLD_WIDTH, WORLD_HEIGHT, ZOOM_SPEED, MINIMAP_WIDTH, MINIMAP_HEIGHT, SHIP_FRICTION, SHIP_DECELERATION, STAR_FIELD_MULTIPLIER, STAR_FIELD_SPREAD, MIN_PARALLAX, MAX_PARALLAX } from './utils/constants.js';
+import {
+  CANVAS_WIDTH,
+  CANVAS_HEIGHT,
+  BULLET_FIRE_RATE,
+  STAR_COUNT,
+  STAR_MIN_BRIGHTNESS,
+  STAR_MAX_BRIGHTNESS,
+  INITIAL_ASTEROID_COUNT,
+  MAX_BULLETS,
+  CONTINUOUS_FIRE_RATE,
+  CROSSHAIR_SIZE,
+  MOUSE_OFFSET,
+  SCORE_PER_ASTEROID,
+  INITIAL_LIVES,
+  STAR_LARGE_THRESHOLD,
+  STAR_MEDIUM_THRESHOLD,
+  WORLD_WIDTH,
+  WORLD_HEIGHT,
+  ZOOM_SPEED,
+  SHIP_FRICTION,
+  SHIP_DECELERATION,
+  STAR_FIELD_MULTIPLIER,
+  STAR_FIELD_SPREAD,
+  MIN_PARALLAX,
+  MAX_PARALLAX,
+  MARGIN_LEFT,
+  MARGIN_RIGHT,
+  MARGIN_TOP,
+  MARGIN_BOTTOM,
+  PLAYFIELD_ASPECT_RATIO,
+  WORLD_ASPECT_RATIO,
+  MINIMAP_WIDTH_RATIO,
+  MAX_MINIMAP_HEIGHT_RATIO,
+  MINIMAP_OVERLAP_RATIO
+} from './utils/constants.js';
 import { Camera } from './utils/camera.js';
 import { Minimap } from './components/Minimap.js';
 import './App.css';
@@ -442,18 +476,8 @@ function App() {
   // Dynamic layout system with fixed margins and locked aspect ratio
   useEffect(() => {
     const updateGameLayout = () => {
-      // Fixed margins
-      const MARGIN_LEFT = 100;
-      const MARGIN_RIGHT = 100;
-      const MARGIN_TOP = 100;
-      const MARGIN_BOTTOM = 200;
-      
-      // Target aspect ratio 1349:817
-      const ASPECT_RATIO = 1349 / 817; // ≈1.6514041591
-      
-      // Minimap sizing: width is a proportion of the play area,
-      // height derived from the WORLD aspect ratio so the shape matches the world.
-      const MINIMAP_WIDTH_RATIO = 0.3276501112; // keep visual width similar to before
+      // Layout metrics
+      const ASPECT_RATIO = PLAYFIELD_ASPECT_RATIO;
       
       // Calculate available box
       const availableWidth = window.innerWidth - MARGIN_LEFT - MARGIN_RIGHT;
@@ -476,11 +500,10 @@ function App() {
       const playY = MARGIN_TOP + Math.round((availableHeight - playHeight) / 2);
       
       // Calculate minimap dimensions using world aspect ratio
-      const worldAspect = WORLD_HEIGHT / WORLD_WIDTH; // H/W
+      const worldAspect = WORLD_ASPECT_RATIO; // H/W
       let minimapWidth = Math.round(playWidth * MINIMAP_WIDTH_RATIO);
       let minimapHeight = Math.round(minimapWidth * worldAspect);
       // Guard: if height would exceed a reasonable portion of play area, cap by height and recompute width
-      const MAX_MINIMAP_HEIGHT_RATIO = 0.2; // at most 20% of play height
       const maxMinimapHeight = Math.round(playHeight * MAX_MINIMAP_HEIGHT_RATIO);
       if (minimapHeight > maxMinimapHeight) {
         minimapHeight = maxMinimapHeight;
@@ -514,7 +537,7 @@ function App() {
       }
 
       // Keep minimap and stats vertically aligned regardless of window size
-      const minimapBottom = -Math.round(minimapHeight * 0.75); // show top 1/4 overlapping play area
+      const minimapBottom = -Math.round(minimapHeight * MINIMAP_OVERLAP_RATIO);
       setLayout(prev => ({ ...prev, minimapBottom }));
       
       // Update constants to match current canvas size for proper rendering
@@ -557,10 +580,10 @@ function App() {
   return (
     <div className="app">
       <div className="play-area">
-        <canvas 
-          ref={canvasRef} 
-          width={1200} 
-          height={900} 
+        <canvas
+          ref={canvasRef}
+          width={CANVAS_WIDTH}
+          height={CANVAS_HEIGHT}
           onClick={handleCanvasClick}
           className="game-canvas"
         />

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -45,9 +45,20 @@ export const ZOOM_SPEED = 0.1;
 // Bullet range (twice viewport width)
 export const BULLET_RANGE = VIEWPORT_WIDTH * 2;
 
-// Minimap
-export const MINIMAP_WIDTH = 160;
-export const MINIMAP_HEIGHT = 120;
+// Layout configuration
+export const MARGIN_LEFT = 100;
+export const MARGIN_RIGHT = 100;
+export const MARGIN_TOP = 100;
+export const MARGIN_BOTTOM = 200;
+
+// Derived aspect ratios
+export const PLAYFIELD_ASPECT_RATIO = CANVAS_WIDTH / CANVAS_HEIGHT;
+export const WORLD_ASPECT_RATIO = WORLD_HEIGHT / WORLD_WIDTH;
+
+// Minimap sizing
+export const MINIMAP_WIDTH_RATIO = 0.3276501112; // proportion of play area width
+export const MAX_MINIMAP_HEIGHT_RATIO = 0.2; // at most 20% of play height
+export const MINIMAP_OVERLAP_RATIO = 0.75; // show top quarter overlapping play area
 
 // Ship physics constants
 export const SHIP_FRICTION = 0.99;


### PR DESCRIPTION
## Summary
- add named layout and minimap ratios derived from canvas/world metrics
- use these constants for responsive play area and minimap sizing

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68c1eba4365c832ab731471b03ca1daa