### PR TITLE
refactor: centralize layout constants

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,7 +3,7 @@ import { Ship } from './components/Ship.js';
 import { Asteroid } from './components/Asteroid.js';
 import { Bullet } from './components/Bullet.js';
 import { checkCollision, wrapPosition } from './utils/collision.js';
-import { CANVAS_WIDTH, CANVAS_HEIGHT, BULLET_FIRE_RATE, STAR_COUNT, STAR_MIN_BRIGHTNESS, STAR_MAX_BRIGHTNESS, INITIAL_ASTEROID_COUNT, MAX_BULLETS, CONTINUOUS_FIRE_RATE, CROSSHAIR_SIZE, MOUSE_OFFSET, SCORE_PER_ASTEROID, INITIAL_LIVES, STAR_LARGE_THRESHOLD, STAR_MEDIUM_THRESHOLD, WORLD_WIDTH, WORLD_HEIGHT, ZOOM_SPEED, MINIMAP_WIDTH, MINIMAP_HEIGHT, SHIP_FRICTION, SHIP_DECELERATION, STAR_FIELD_MULTIPLIER, STAR_FIELD_SPREAD, MIN_PARALLAX, MAX_PARALLAX } from './utils/constants.js';
+import { CANVAS_WIDTH, CANVAS_HEIGHT, BULLET_FIRE_RATE, STAR_COUNT, STAR_MIN_BRIGHTNESS, STAR_MAX_BRIGHTNESS, INITIAL_ASTEROID_COUNT, MAX_BULLETS, CONTINUOUS_FIRE_RATE, CROSSHAIR_SIZE, MOUSE_OFFSET, SCORE_PER_ASTEROID, INITIAL_LIVES, STAR_LARGE_THRESHOLD, STAR_MEDIUM_THRESHOLD, WORLD_WIDTH, WORLD_HEIGHT, ZOOM_SPEED, SHIP_FRICTION, SHIP_DECELERATION, STAR_FIELD_MULTIPLIER, STAR_FIELD_SPREAD, MIN_PARALLAX, MAX_PARALLAX, MARGIN_LEFT, MARGIN_RIGHT, MARGIN_TOP, MARGIN_BOTTOM, TARGET_ASPECT_RATIO, MINIMAP_WIDTH_RATIO, MAX_MINIMAP_HEIGHT_RATIO, MINIMAP_OVERLAP_RATIO } from './utils/constants.js';
 import { Camera } from './utils/camera.js';
 import { Minimap } from './components/Minimap.js';
 import './App.css';
@@ -442,51 +442,38 @@ function App() {
   // Dynamic layout system with fixed margins and locked aspect ratio
   useEffect(() => {
     const updateGameLayout = () => {
-      // Fixed margins
-      const MARGIN_LEFT = 100;
-      const MARGIN_RIGHT = 100;
-      const MARGIN_TOP = 100;
-      const MARGIN_BOTTOM = 200;
-      
-      // Target aspect ratio 1349:817
-      const ASPECT_RATIO = 1349 / 817; // ≈1.6514041591
-      
-      // Minimap sizing: width is a proportion of the play area,
-      // height derived from the WORLD aspect ratio so the shape matches the world.
-      const MINIMAP_WIDTH_RATIO = 0.3276501112; // keep visual width similar to before
-      
       // Calculate available box
       const availableWidth = window.innerWidth - MARGIN_LEFT - MARGIN_RIGHT;
       const availableHeight = window.innerHeight - MARGIN_TOP - MARGIN_BOTTOM;
-      
+
       // Calculate play area size maintaining aspect ratio
       let playWidth, playHeight;
-      if (availableWidth / availableHeight > ASPECT_RATIO) {
+      if (availableWidth / availableHeight > TARGET_ASPECT_RATIO) {
         // Height-constrained
         playHeight = availableHeight;
-        playWidth = Math.round(playHeight * ASPECT_RATIO);
+        playWidth = Math.round(playHeight * TARGET_ASPECT_RATIO);
       } else {
         // Width-constrained
         playWidth = availableWidth;
-        playHeight = Math.round(playWidth / ASPECT_RATIO);
+        playHeight = Math.round(playWidth / TARGET_ASPECT_RATIO);
       }
-      
+
       // Center play area within available box
       const playX = MARGIN_LEFT + Math.round((availableWidth - playWidth) / 2);
       const playY = MARGIN_TOP + Math.round((availableHeight - playHeight) / 2);
-      
+
       // Calculate minimap dimensions using world aspect ratio
       const worldAspect = WORLD_HEIGHT / WORLD_WIDTH; // H/W
+      // Width is a proportion of the play area; height derived from world aspect ratio
       let minimapWidth = Math.round(playWidth * MINIMAP_WIDTH_RATIO);
       let minimapHeight = Math.round(minimapWidth * worldAspect);
       // Guard: if height would exceed a reasonable portion of play area, cap by height and recompute width
-      const MAX_MINIMAP_HEIGHT_RATIO = 0.2; // at most 20% of play height
       const maxMinimapHeight = Math.round(playHeight * MAX_MINIMAP_HEIGHT_RATIO);
       if (minimapHeight > maxMinimapHeight) {
         minimapHeight = maxMinimapHeight;
         minimapWidth = Math.round(minimapHeight / worldAspect);
       }
-      
+
       // Apply styles to play area
       const playArea = document.querySelector('.play-area');
       if (playArea) {
@@ -514,7 +501,7 @@ function App() {
       }
 
       // Keep minimap and stats vertically aligned regardless of window size
-      const minimapBottom = -Math.round(minimapHeight * 0.75); // show top 1/4 overlapping play area
+      const minimapBottom = -Math.round(minimapHeight * MINIMAP_OVERLAP_RATIO); // show top 1/4 overlapping play area
       setLayout(prev => ({ ...prev, minimapBottom }));
       
       // Update constants to match current canvas size for proper rendering

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -49,6 +49,20 @@ export const BULLET_RANGE = VIEWPORT_WIDTH * 2;
 export const MINIMAP_WIDTH = 160;
 export const MINIMAP_HEIGHT = 120;
 
+// Layout
+export const MARGIN_LEFT = 100;
+export const MARGIN_RIGHT = 100;
+export const MARGIN_TOP = 100;
+export const MARGIN_BOTTOM = 200;
+
+// Target aspect ratio 1349:817
+export const TARGET_ASPECT_RATIO = 1349 / 817;
+
+// Minimap sizing ratios
+export const MINIMAP_WIDTH_RATIO = 0.3276501112; // keep visual width similar to before
+export const MAX_MINIMAP_HEIGHT_RATIO = 0.2; // at most 20% of play height
+export const MINIMAP_OVERLAP_RATIO = 0.75; // show top 1/4 overlapping play area
+
 // Ship physics constants
 export const SHIP_FRICTION = 0.99;
 export const SHIP_DECELERATION = 0.92;


### PR DESCRIPTION
## Summary
- define constants for layout margins, target aspect ratio, and minimap ratios
- update game layout calculations to use the new constants

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1eb9c9e24832a864ac3487875069d