### PR TITLE
fix: enable wheel event prevention

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -139,7 +139,7 @@ function App() {
     document.addEventListener('mousemove', handleMouseMove);
     document.addEventListener('mousedown', handleMouseDown);
     document.addEventListener('mouseup', handleMouseUp);
-    document.addEventListener('wheel', handleWheel, { passive: true });
+    document.addEventListener('wheel', handleWheel);
     
     return () => {
       window.removeEventListener('keydown', handleKeyDown);


### PR DESCRIPTION
## Summary
- allow wheel event handler to prevent default scrolling

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1ea80d648832a9e74a4c9c95268a2