### PR TITLE
Use ref for canvas dimensions

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -25,6 +25,7 @@ function App() {
   const starsRef = useRef([]);
   const mousePositionRef = useRef({ x: 0, y: 0 });
   const isMouseDownRef = useRef(false);
+  const canvasSizeRef = useRef({ width: CANVAS_WIDTH, height: CANVAS_HEIGHT });
   // Simplified firing: handled in the main update loop via a single timer
   const [uiState, setUiState] = useState({
     score: 0,
@@ -236,8 +237,7 @@ function App() {
     wrapPosition(ship); // World wrapping
 
     // Update camera to follow ship
-    const canvasWidth = window.currentCanvasWidth || CANVAS_WIDTH;
-    const canvasHeight = window.currentCanvasHeight || CANVAS_HEIGHT;
+    const { width: canvasWidth, height: canvasHeight } = canvasSizeRef.current;
     camera.followShip(ship.x, ship.y, canvasWidth, canvasHeight);
 
     // Update asteroids
@@ -316,8 +316,7 @@ function App() {
     const canvas = canvasRef.current;
     if (!canvas) return;
     const ctx = canvas.getContext('2d');
-    const canvasWidth = window.currentCanvasWidth || CANVAS_WIDTH;
-    const canvasHeight = window.currentCanvasHeight || CANVAS_HEIGHT;
+    const { width: canvasWidth, height: canvasHeight } = canvasSizeRef.current;
     ctx.clearRect(0, 0, canvasWidth, canvasHeight);
 
     const camera = cameraRef.current;
@@ -520,10 +519,12 @@ function App() {
       // Update constants to match current canvas size for proper rendering
       const updatedCanvasWidth = playWidth - 4;
       const updatedCanvasHeight = playHeight - 4;
-      
+
       // Store current canvas dimensions for use in rendering
-      window.currentCanvasWidth = updatedCanvasWidth;
-      window.currentCanvasHeight = updatedCanvasHeight;
+      canvasSizeRef.current = {
+        width: updatedCanvasWidth,
+        height: updatedCanvasHeight
+      };
       
       // Debug logging
       console.log('Layout calc:', {


### PR DESCRIPTION
## Summary
- store canvas dimensions in a dedicated `canvasSizeRef`
- read canvas width/height from `canvasSizeRef` instead of `window` globals
- remove global `window.currentCanvasWidth/Height` assignments

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1ea81e64c832ab860da80b71e595d