### PR TITLE
chore: remove unused key filters

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -82,11 +82,10 @@ function App() {
   // Handle pointer lock and mouse/keyboard input
   useEffect(() => {
     const handleKeyDown = (e) => {
-      if (['KeyA', 'KeyD', 'KeyW', 'KeyS', 'Space', 'Escape'].includes(e.code)) {
+      if (['KeyW', 'KeyS', 'Space', 'Escape'].includes(e.code)) {
         e.preventDefault();
       }
-      
-      
+
       keysRef.current[e.code] = true;
     };
     


### PR DESCRIPTION
## Summary
- remove KeyA and KeyD from keydown handler since no rotation

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68c1eb74e18c832a9791b821347d63df