### PR TITLE
Use shared visibility margin constant

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,7 +3,7 @@ import { Ship } from './components/Ship.js';
 import { Asteroid } from './components/Asteroid.js';
 import { Bullet } from './components/Bullet.js';
 import { checkCollision, wrapPosition } from './utils/collision.js';
-import { CANVAS_WIDTH, CANVAS_HEIGHT, BULLET_FIRE_RATE, STAR_COUNT, STAR_MIN_BRIGHTNESS, STAR_MAX_BRIGHTNESS, INITIAL_ASTEROID_COUNT, MAX_BULLETS, CONTINUOUS_FIRE_RATE, CROSSHAIR_SIZE, MOUSE_OFFSET, SCORE_PER_ASTEROID, INITIAL_LIVES, STAR_LARGE_THRESHOLD, STAR_MEDIUM_THRESHOLD, WORLD_WIDTH, WORLD_HEIGHT, ZOOM_SPEED, MINIMAP_WIDTH, MINIMAP_HEIGHT, SHIP_FRICTION, SHIP_DECELERATION, STAR_FIELD_MULTIPLIER, STAR_FIELD_SPREAD, MIN_PARALLAX, MAX_PARALLAX } from './utils/constants.js';
+import { CANVAS_WIDTH, CANVAS_HEIGHT, BULLET_FIRE_RATE, STAR_COUNT, STAR_MIN_BRIGHTNESS, STAR_MAX_BRIGHTNESS, INITIAL_ASTEROID_COUNT, MAX_BULLETS, CONTINUOUS_FIRE_RATE, CROSSHAIR_SIZE, MOUSE_OFFSET, SCORE_PER_ASTEROID, INITIAL_LIVES, STAR_LARGE_THRESHOLD, STAR_MEDIUM_THRESHOLD, WORLD_WIDTH, WORLD_HEIGHT, ZOOM_SPEED, MINIMAP_WIDTH, MINIMAP_HEIGHT, SHIP_FRICTION, SHIP_DECELERATION, STAR_FIELD_MULTIPLIER, STAR_FIELD_SPREAD, MIN_PARALLAX, MAX_PARALLAX, VISIBILITY_MARGIN } from './utils/constants.js';
 import { Camera } from './utils/camera.js';
 import { Minimap } from './components/Minimap.js';
 import './App.css';
@@ -331,8 +331,8 @@ function App() {
       const screenPos = camera.worldToScreen(parallaxX, parallaxY, canvasWidth, canvasHeight);
       
       // Only draw if visible (with margin for star wrapping)
-      if (screenPos.x >= -50 && screenPos.x <= canvasWidth + 50 && 
-          screenPos.y >= -50 && screenPos.y <= canvasHeight + 50) {
+      if (screenPos.x >= -VISIBILITY_MARGIN && screenPos.x <= canvasWidth + VISIBILITY_MARGIN &&
+          screenPos.y >= -VISIBILITY_MARGIN && screenPos.y <= canvasHeight + VISIBILITY_MARGIN) {
         ctx.save();
         ctx.globalAlpha = star.brightness;
         ctx.fillStyle = 'white';
@@ -342,7 +342,7 @@ function App() {
     });
 
     // Draw ship
-    if (shipRef.current && camera.isVisible(shipRef.current.x, shipRef.current.y, 50, canvasWidth, canvasHeight)) {
+    if (shipRef.current && camera.isVisible(shipRef.current.x, shipRef.current.y, VISIBILITY_MARGIN, canvasWidth, canvasHeight)) {
       const screenPos = camera.worldToScreen(shipRef.current.x, shipRef.current.y, canvasWidth, canvasHeight);
       ctx.save();
       ctx.translate(screenPos.x, screenPos.y);

--- a/src/utils/camera.js
+++ b/src/utils/camera.js
@@ -1,4 +1,4 @@
-import { WORLD_WIDTH, WORLD_HEIGHT, VIEWPORT_WIDTH, VIEWPORT_HEIGHT, MIN_ZOOM, MAX_ZOOM_OUT, ZOOM_INTERPOLATION } from './constants.js';
+import { WORLD_WIDTH, WORLD_HEIGHT, VIEWPORT_WIDTH, VIEWPORT_HEIGHT, MIN_ZOOM, MAX_ZOOM_OUT, ZOOM_INTERPOLATION, VISIBILITY_MARGIN } from './constants.js';
 
 export class Camera {
   constructor(x = WORLD_WIDTH / 2, y = WORLD_HEIGHT / 2) {
@@ -60,7 +60,7 @@ export class Camera {
   }
 
   // Check if a world position is visible in the viewport
-  isVisible(worldX, worldY, margin = 50, viewportWidth = VIEWPORT_WIDTH, viewportHeight = VIEWPORT_HEIGHT) {
+  isVisible(worldX, worldY, margin = VISIBILITY_MARGIN, viewportWidth = VIEWPORT_WIDTH, viewportHeight = VIEWPORT_HEIGHT) {
     const effectiveViewportWidth = viewportWidth * this.zoom;
     const effectiveViewportHeight = viewportHeight * this.zoom;
     

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -55,6 +55,7 @@ export const SHIP_DECELERATION = 0.92;
 
 // Camera constants
 export const ZOOM_INTERPOLATION = 0.1;
+export const VISIBILITY_MARGIN = 50;
 
 // Starfield generation constants
 export const STAR_FIELD_MULTIPLIER = 3;


### PR DESCRIPTION
## Summary
- add `VISIBILITY_MARGIN` constant
- use constant for Camera visibility checks and star rendering

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1eb765af4832ab610074646f8bbec