### PR TITLE
Use ref for play area layout updates

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,7 @@ import { Minimap } from './components/Minimap.js';
 import './App.css';
 
 function App() {
+  const playAreaRef = useRef(null);
   const canvasRef = useRef(null);
   const minimapCanvasRef = useRef(null);
   const shipRef = useRef(new Ship(WORLD_WIDTH / 2, WORLD_HEIGHT / 2));
@@ -488,7 +489,7 @@ function App() {
       }
       
       // Apply styles to play area
-      const playArea = document.querySelector('.play-area');
+      const playArea = playAreaRef.current;
       if (playArea) {
         playArea.style.left = `${playX}px`;
         playArea.style.top = `${playY}px`;
@@ -556,7 +557,7 @@ function App() {
 
   return (
     <div className="app">
-      <div className="play-area">
+      <div className="play-area" ref={playAreaRef}>
         <canvas 
           ref={canvasRef} 
           width={1200} 


### PR DESCRIPTION
## Summary
- use `playAreaRef` to access play area div
- rely on `playAreaRef.current` in `updateGameLayout` instead of `document.querySelector`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68c1eb792638832abc5adb8c128e3d66