### PR TITLE
Remove layout setTimeout and call updateGameLayout on mount

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -540,15 +540,13 @@ function App() {
       });
     };
 
-    // Initial layout calculation with a small delay to ensure DOM is ready
-    const timeoutId = setTimeout(updateGameLayout, 10);
+    // Perform initial layout calculation and set up listeners
     updateGameLayout();
-    
+
     window.addEventListener('resize', updateGameLayout);
     window.addEventListener('orientationchange', updateGameLayout);
-    
+
     return () => {
-      clearTimeout(timeoutId);
       window.removeEventListener('resize', updateGameLayout);
       window.removeEventListener('orientationchange', updateGameLayout);
     };


### PR DESCRIPTION
## Summary
- Simplify layout initialization by removing the setTimeout wrapper
- Invoke `updateGameLayout` once on mount and keep resize/orientation listeners

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1eb7b96e0832a92f0b699338fcef3