### PR TITLE
refactor: centralize color constants

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,7 +3,7 @@ import { Ship } from './components/Ship.js';
 import { Asteroid } from './components/Asteroid.js';
 import { Bullet } from './components/Bullet.js';
 import { checkCollision, wrapPosition } from './utils/collision.js';
-import { CANVAS_WIDTH, CANVAS_HEIGHT, BULLET_FIRE_RATE, STAR_COUNT, STAR_MIN_BRIGHTNESS, STAR_MAX_BRIGHTNESS, INITIAL_ASTEROID_COUNT, MAX_BULLETS, CONTINUOUS_FIRE_RATE, CROSSHAIR_SIZE, MOUSE_OFFSET, SCORE_PER_ASTEROID, INITIAL_LIVES, STAR_LARGE_THRESHOLD, STAR_MEDIUM_THRESHOLD, WORLD_WIDTH, WORLD_HEIGHT, ZOOM_SPEED, MINIMAP_WIDTH, MINIMAP_HEIGHT, SHIP_FRICTION, SHIP_DECELERATION, STAR_FIELD_MULTIPLIER, STAR_FIELD_SPREAD, MIN_PARALLAX, MAX_PARALLAX } from './utils/constants.js';
+import { CANVAS_WIDTH, CANVAS_HEIGHT, BULLET_FIRE_RATE, STAR_COUNT, STAR_MIN_BRIGHTNESS, STAR_MAX_BRIGHTNESS, INITIAL_ASTEROID_COUNT, MAX_BULLETS, CONTINUOUS_FIRE_RATE, CROSSHAIR_SIZE, MOUSE_OFFSET, SCORE_PER_ASTEROID, INITIAL_LIVES, STAR_LARGE_THRESHOLD, STAR_MEDIUM_THRESHOLD, WORLD_WIDTH, WORLD_HEIGHT, ZOOM_SPEED, MINIMAP_WIDTH, MINIMAP_HEIGHT, SHIP_FRICTION, SHIP_DECELERATION, STAR_FIELD_MULTIPLIER, STAR_FIELD_SPREAD, MIN_PARALLAX, MAX_PARALLAX, SHIP_COLOR, BULLET_COLOR, STAR_COLOR, CROSSHAIR_COLOR, HUD_TEXT_COLOR } from './utils/constants.js';
 import { Camera } from './utils/camera.js';
 import { Minimap } from './components/Minimap.js';
 import './App.css';
@@ -335,7 +335,7 @@ function App() {
           screenPos.y >= -50 && screenPos.y <= canvasHeight + 50) {
         ctx.save();
         ctx.globalAlpha = star.brightness;
-        ctx.fillStyle = 'white';
+        ctx.fillStyle = STAR_COLOR;
         ctx.fillRect(screenPos.x, screenPos.y, star.size / camera.zoom, star.size / camera.zoom);
         ctx.restore();
       }
@@ -355,7 +355,7 @@ function App() {
       ctx.lineTo(-size / 2, -size / 2);
       ctx.lineTo(-size / 2, size / 2);
       ctx.closePath();
-      ctx.strokeStyle = 'white';
+      ctx.strokeStyle = SHIP_COLOR;
       ctx.stroke();
       ctx.restore();
     }
@@ -380,7 +380,7 @@ function App() {
         const screenPos = camera.worldToScreen(bullet.x, bullet.y, canvasWidth, canvasHeight);
         ctx.beginPath();
         ctx.arc(screenPos.x, screenPos.y, bullet.size / camera.zoom, 0, Math.PI * 2);
-        ctx.fillStyle = 'white';
+        ctx.fillStyle = BULLET_COLOR;
         ctx.fill();
       }
     });
@@ -389,7 +389,7 @@ function App() {
     if (gameStartedRef.current) {
       const mousePos = mousePositionRef.current;
       const screenPos = camera.worldToScreen(mousePos.x, mousePos.y, canvasWidth, canvasHeight);
-      ctx.strokeStyle = 'white';
+      ctx.strokeStyle = CROSSHAIR_COLOR;
       ctx.lineWidth = 2;
       ctx.beginPath();
       // Horizontal line
@@ -587,7 +587,7 @@ function App() {
           gap: '32px',
           fontSize: '20px',
           fontWeight: 'bold',
-          color: 'white'
+          color: HUD_TEXT_COLOR
         }}>
           <div>Score: {uiState.score}</div>
           <div>Lives: {uiState.lives}</div>

--- a/src/components/Asteroid.js
+++ b/src/components/Asteroid.js
@@ -1,4 +1,4 @@
-import { ASTEROID_SPEED, ASTEROID_SIZE_LARGE, ASTEROID_SIZE_MEDIUM, ASTEROID_SIZE_SMALL } from '../utils/constants.js';
+import { ASTEROID_SPEED, ASTEROID_SIZE_LARGE, ASTEROID_SIZE_MEDIUM, ASTEROID_SIZE_SMALL, ASTEROID_COLOR } from '../utils/constants.js';
 
 export class Asteroid {
   constructor(x, y, size = ASTEROID_SIZE_LARGE, parentVelocity = null) {
@@ -56,7 +56,7 @@ export class Asteroid {
     }
     
     ctx.closePath();
-    ctx.strokeStyle = 'white';
+    ctx.strokeStyle = ASTEROID_COLOR;
     ctx.stroke();
     ctx.restore();
   }

--- a/src/components/Bullet.js
+++ b/src/components/Bullet.js
@@ -1,4 +1,4 @@
-import { BULLET_SPEED, BULLET_LIFETIME, BULLET_SIZE, BULLET_RANGE } from '../utils/constants.js';
+import { BULLET_SPEED, BULLET_LIFETIME, BULLET_SIZE, BULLET_RANGE, BULLET_COLOR } from '../utils/constants.js';
 
 export class Bullet {
   constructor(x, y, angle) {
@@ -27,7 +27,7 @@ export class Bullet {
   draw(ctx) {
     ctx.beginPath();
     ctx.arc(this.x, this.y, this.size, 0, Math.PI * 2);
-    ctx.fillStyle = 'white';
+    ctx.fillStyle = BULLET_COLOR;
     ctx.fill();
   }
 

--- a/src/components/Minimap.js
+++ b/src/components/Minimap.js
@@ -1,4 +1,4 @@
-import { WORLD_WIDTH, WORLD_HEIGHT, VIEWPORT_WIDTH, VIEWPORT_HEIGHT } from '../utils/constants.js';
+import { WORLD_WIDTH, WORLD_HEIGHT, VIEWPORT_WIDTH, VIEWPORT_HEIGHT, MINIMAP_BG_COLOR, MINIMAP_ASTEROID_COLOR, SHIP_COLOR, MINIMAP_VIEWPORT_COLOR } from '../utils/constants.js';
 
 export class Minimap {
   static draw(ctx, ship, asteroids, camera) {
@@ -9,7 +9,7 @@ export class Minimap {
     // Clear and draw background (border is handled by CSS on the canvas)
     ctx.clearRect(0, 0, w, h);
     ctx.save();
-    ctx.fillStyle = 'rgba(0, 0, 0, 0.9)';
+    ctx.fillStyle = MINIMAP_BG_COLOR;
     ctx.fillRect(0, 0, w, h);
 
     // Scale factors
@@ -17,7 +17,7 @@ export class Minimap {
     const scaleY = h / WORLD_HEIGHT;
     
     // Draw asteroids as small gray dots
-    ctx.fillStyle = 'gray';
+    ctx.fillStyle = MINIMAP_ASTEROID_COLOR;
     asteroids.forEach(asteroid => {
       if (asteroid) {
         const x = asteroid.x * scaleX;
@@ -30,11 +30,11 @@ export class Minimap {
     if (ship) {
       const shipX = ship.x * scaleX;
       const shipY = ship.y * scaleY;
-      ctx.fillStyle = 'white';
+      ctx.fillStyle = SHIP_COLOR;
       ctx.fillRect(shipX - 1.5, shipY - 1.5, 3, 3);
       
       // Draw ship direction indicator
-      ctx.strokeStyle = 'white';
+      ctx.strokeStyle = SHIP_COLOR;
       ctx.lineWidth = 1;
       ctx.beginPath();
       ctx.moveTo(shipX, shipY);
@@ -53,7 +53,7 @@ export class Minimap {
     const viewW = effectiveViewportWidth * scaleX;
     const viewH = effectiveViewportHeight * scaleY;
     
-    ctx.strokeStyle = 'yellow';
+    ctx.strokeStyle = MINIMAP_VIEWPORT_COLOR;
     ctx.lineWidth = 1;
     ctx.strokeRect(viewX, viewY, viewW, viewH);
     

--- a/src/components/Ship.js
+++ b/src/components/Ship.js
@@ -1,4 +1,4 @@
-import { SHIP_SIZE, SHIP_SPEED } from '../utils/constants.js';
+import { SHIP_SIZE, SHIP_SPEED, SHIP_COLOR } from '../utils/constants.js';
 
 export class Ship {
   constructor(x, y) {
@@ -20,7 +20,7 @@ export class Ship {
     ctx.lineTo(-this.size / 2, -this.size / 2);
     ctx.lineTo(-this.size / 2, this.size / 2);
     ctx.closePath();
-    ctx.strokeStyle = 'white';
+    ctx.strokeStyle = SHIP_COLOR;
     ctx.stroke();
     ctx.restore();
   }

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -61,3 +61,14 @@ export const STAR_FIELD_MULTIPLIER = 3;
 export const STAR_FIELD_SPREAD = 1.5;
 export const MIN_PARALLAX = 0.3;
 export const MAX_PARALLAX = 0.7;
+
+// Color constants
+export const SHIP_COLOR = 'white';
+export const BULLET_COLOR = 'white';
+export const ASTEROID_COLOR = 'white';
+export const STAR_COLOR = 'white';
+export const CROSSHAIR_COLOR = 'white';
+export const MINIMAP_BG_COLOR = 'rgba(0, 0, 0, 0.9)';
+export const MINIMAP_ASTEROID_COLOR = 'gray';
+export const MINIMAP_VIEWPORT_COLOR = 'yellow';
+export const HUD_TEXT_COLOR = 'white';


### PR DESCRIPTION
## Summary
- add shared color constants in utils/constants.js
- replace hardcoded color strings in Asteroid, Bullet, Minimap, Ship, and App components

## Testing
- `npm run lint` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c1eb81d290832ab2562d5800723bdf