### PR TITLE
refactor: modularize rendering and layout logic

### DIFF
--- a/src/hooks/useRendering.js
+++ b/src/hooks/useRendering.js
@@ -1,0 +1,93 @@
+import { useCallback } from 'react';
+import { CANVAS_WIDTH, CANVAS_HEIGHT, CROSSHAIR_SIZE } from '../utils/constants.js';
+import { Minimap } from '../components/Minimap.js';
+
+export function useRendering({ canvasRef, minimapCanvasRef, starsRef, shipRef, cameraRef, asteroidsRef, bulletsRef, mousePositionRef, gameStartedRef }) {
+  const renderMinimap = useCallback(() => {
+    const minimapCanvas = minimapCanvasRef.current;
+    if (!minimapCanvas) return;
+    const ctx = minimapCanvas.getContext('2d');
+    Minimap.draw(ctx, shipRef.current, asteroidsRef.current, cameraRef.current);
+  }, [minimapCanvasRef, shipRef, asteroidsRef, cameraRef]);
+
+  const render = useCallback(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    const canvasWidth = window.currentCanvasWidth || CANVAS_WIDTH;
+    const canvasHeight = window.currentCanvasHeight || CANVAS_HEIGHT;
+    ctx.clearRect(0, 0, canvasWidth, canvasHeight);
+
+    const camera = cameraRef.current;
+
+    starsRef.current.forEach((star) => {
+      const parallaxX = star.x - camera.x * star.parallax;
+      const parallaxY = star.y - camera.y * star.parallax;
+      const screenPos = camera.worldToScreen(parallaxX, parallaxY, canvasWidth, canvasHeight);
+      if (screenPos.x >= -50 && screenPos.x <= canvasWidth + 50 &&
+          screenPos.y >= -50 && screenPos.y <= canvasHeight + 50) {
+        ctx.save();
+        ctx.globalAlpha = star.brightness;
+        ctx.fillStyle = 'white';
+        ctx.fillRect(screenPos.x, screenPos.y, star.size / camera.zoom, star.size / camera.zoom);
+        ctx.restore();
+      }
+    });
+
+    if (shipRef.current && camera.isVisible(shipRef.current.x, shipRef.current.y, 50, canvasWidth, canvasHeight)) {
+      const screenPos = camera.worldToScreen(shipRef.current.x, shipRef.current.y, canvasWidth, canvasHeight);
+      ctx.save();
+      ctx.translate(screenPos.x, screenPos.y);
+      ctx.scale(1 / camera.zoom, 1 / camera.zoom);
+      ctx.rotate(shipRef.current.angle);
+      const size = shipRef.current.size;
+      ctx.beginPath();
+      ctx.moveTo(size, 0);
+      ctx.lineTo(-size / 2, -size / 2);
+      ctx.lineTo(-size / 2, size / 2);
+      ctx.closePath();
+      ctx.strokeStyle = 'white';
+      ctx.stroke();
+      ctx.restore();
+    }
+
+    asteroidsRef.current.forEach((asteroid) => {
+      if (asteroid && camera.isVisible(asteroid.x, asteroid.y, asteroid.size, canvasWidth, canvasHeight)) {
+        const screenPos = camera.worldToScreen(asteroid.x, asteroid.y, canvasWidth, canvasHeight);
+        ctx.save();
+        ctx.translate(screenPos.x, screenPos.y);
+        ctx.scale(1 / camera.zoom, 1 / camera.zoom);
+        ctx.translate(-asteroid.x, -asteroid.y);
+        asteroid.draw(ctx);
+        ctx.restore();
+      }
+    });
+
+    bulletsRef.current.forEach((bullet) => {
+      if (bullet && camera.isVisible(bullet.x, bullet.y, bullet.size, canvasWidth, canvasHeight)) {
+        const screenPos = camera.worldToScreen(bullet.x, bullet.y, canvasWidth, canvasHeight);
+        ctx.beginPath();
+        ctx.arc(screenPos.x, screenPos.y, bullet.size / camera.zoom, 0, Math.PI * 2);
+        ctx.fillStyle = 'white';
+        ctx.fill();
+      }
+    });
+
+    if (gameStartedRef.current) {
+      const mousePos = mousePositionRef.current;
+      const screenPos = camera.worldToScreen(mousePos.x, mousePos.y, canvasWidth, canvasHeight);
+      ctx.strokeStyle = 'white';
+      ctx.lineWidth = 2;
+      ctx.beginPath();
+      ctx.moveTo(screenPos.x - CROSSHAIR_SIZE, screenPos.y);
+      ctx.lineTo(screenPos.x + CROSSHAIR_SIZE, screenPos.y);
+      ctx.moveTo(screenPos.x, screenPos.y - CROSSHAIR_SIZE);
+      ctx.lineTo(screenPos.x, screenPos.y + CROSSHAIR_SIZE);
+      ctx.stroke();
+    }
+
+    renderMinimap();
+  }, [canvasRef, cameraRef, starsRef, shipRef, asteroidsRef, bulletsRef, mousePositionRef, gameStartedRef, renderMinimap]);
+
+  return { render };
+}

--- a/src/hooks/useResponsiveLayout.js
+++ b/src/hooks/useResponsiveLayout.js
@@ -1,0 +1,97 @@
+import { useEffect } from 'react';
+import { WORLD_WIDTH, WORLD_HEIGHT } from '../utils/constants.js';
+
+export function useResponsiveLayout(canvasRef, minimapCanvasRef, setLayout) {
+  useEffect(() => {
+    const updateGameLayout = () => {
+      const MARGIN_LEFT = 100;
+      const MARGIN_RIGHT = 100;
+      const MARGIN_TOP = 100;
+      const MARGIN_BOTTOM = 200;
+
+      const ASPECT_RATIO = 1349 / 817;
+      const MINIMAP_WIDTH_RATIO = 0.3276501112;
+
+      const availableWidth = window.innerWidth - MARGIN_LEFT - MARGIN_RIGHT;
+      const availableHeight = window.innerHeight - MARGIN_TOP - MARGIN_BOTTOM;
+
+      let playWidth, playHeight;
+      if (availableWidth / availableHeight > ASPECT_RATIO) {
+        playHeight = availableHeight;
+        playWidth = Math.round(playHeight * ASPECT_RATIO);
+      } else {
+        playWidth = availableWidth;
+        playHeight = Math.round(playWidth / ASPECT_RATIO);
+      }
+
+      const playX = MARGIN_LEFT + Math.round((availableWidth - playWidth) / 2);
+      const playY = MARGIN_TOP + Math.round((availableHeight - playHeight) / 2);
+
+      const worldAspect = WORLD_HEIGHT / WORLD_WIDTH;
+      let minimapWidth = Math.round(playWidth * MINIMAP_WIDTH_RATIO);
+      let minimapHeight = Math.round(minimapWidth * worldAspect);
+      const MAX_MINIMAP_HEIGHT_RATIO = 0.2;
+      const maxMinimapHeight = Math.round(playHeight * MAX_MINIMAP_HEIGHT_RATIO);
+      if (minimapHeight > maxMinimapHeight) {
+        minimapHeight = maxMinimapHeight;
+        minimapWidth = Math.round(minimapHeight / worldAspect);
+      }
+
+      const playArea = document.querySelector('.play-area');
+      if (playArea) {
+        playArea.style.left = `${playX}px`;
+        playArea.style.top = `${playY}px`;
+        playArea.style.width = `${playWidth}px`;
+        playArea.style.height = `${playHeight}px`;
+      }
+
+      const canvas = canvasRef.current;
+      if (canvas) {
+        canvas.width = playWidth - 4;
+        canvas.height = playHeight - 4;
+      }
+
+      const minimapCanvas = minimapCanvasRef.current;
+      if (minimapCanvas) {
+        minimapCanvas.width = minimapWidth;
+        minimapCanvas.height = minimapHeight;
+        minimapCanvas.style.width = `${minimapWidth}px`;
+        minimapCanvas.style.height = `${minimapHeight}px`;
+        console.log('Minimap dimensions set:', minimapWidth, minimapHeight);
+      }
+
+      const minimapBottom = -Math.round(minimapHeight * 0.75);
+      setLayout(prev => ({ ...prev, minimapBottom }));
+
+      const updatedCanvasWidth = playWidth - 4;
+      const updatedCanvasHeight = playHeight - 4;
+      window.currentCanvasWidth = updatedCanvasWidth;
+      window.currentCanvasHeight = updatedCanvasHeight;
+
+      console.log('Layout calc:', {
+        windowWidth: window.innerWidth,
+        windowHeight: window.innerHeight,
+        availableWidth,
+        availableHeight,
+        playWidth,
+        playHeight,
+        playX,
+        playY,
+        minimapWidth,
+        minimapHeight
+      });
+    };
+
+    const timeoutId = setTimeout(updateGameLayout, 10);
+    updateGameLayout();
+
+    window.addEventListener('resize', updateGameLayout);
+    window.addEventListener('orientationchange', updateGameLayout);
+
+    return () => {
+      clearTimeout(timeoutId);
+      window.removeEventListener('resize', updateGameLayout);
+      window.removeEventListener('orientationchange', updateGameLayout);
+    };
+  }, [canvasRef, minimapCanvasRef, setLayout]);
+}

--- a/src/hooks/useStarfield.js
+++ b/src/hooks/useStarfield.js
@@ -1,0 +1,27 @@
+import { useCallback, useRef } from 'react';
+import { STAR_COUNT, STAR_MIN_BRIGHTNESS, STAR_MAX_BRIGHTNESS, STAR_LARGE_THRESHOLD, STAR_MEDIUM_THRESHOLD, WORLD_WIDTH, WORLD_HEIGHT, STAR_FIELD_MULTIPLIER, STAR_FIELD_SPREAD, MIN_PARALLAX, MAX_PARALLAX } from '../utils/constants.js';
+
+export function useStarfield() {
+  const starsRef = useRef([]);
+
+  const generateStarfield = useCallback(() => {
+    const stars = [];
+    for (let i = 0; i < STAR_COUNT * STAR_FIELD_MULTIPLIER; i++) {
+      const u1 = Math.random();
+      const u2 = Math.random();
+      const z0 = Math.sqrt(-2 * Math.log(u1)) * Math.cos(2 * Math.PI * u2);
+      let brightness = 0.5 + z0 * 0.15;
+      brightness = Math.max(STAR_MIN_BRIGHTNESS, Math.min(STAR_MAX_BRIGHTNESS, brightness));
+      stars.push({
+        x: Math.random() * WORLD_WIDTH * STAR_FIELD_SPREAD,
+        y: Math.random() * WORLD_HEIGHT * STAR_FIELD_SPREAD,
+        brightness: brightness,
+        size: brightness > STAR_LARGE_THRESHOLD ? 2 : brightness > STAR_MEDIUM_THRESHOLD ? 1.5 : 1,
+        parallax: MIN_PARALLAX + Math.random() * (MAX_PARALLAX - MIN_PARALLAX)
+      });
+    }
+    starsRef.current = stars;
+  }, []);
+
+  return { starsRef, generateStarfield };
+}


### PR DESCRIPTION
## Summary
- move starfield generation into `useStarfield` hook
- extract responsive layout calculations to `useResponsiveLayout`
- centralize canvas and minimap drawing in `useRendering`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1eb95c518832a8126a4f6938b74c1