### PR TITLE
Use constants for canvas dimensions

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -557,10 +557,10 @@ function App() {
   return (
     <div className="app">
       <div className="play-area">
-        <canvas 
-          ref={canvasRef} 
-          width={1200} 
-          height={900} 
+        <canvas
+          ref={canvasRef}
+          width={CANVAS_WIDTH}
+          height={CANVAS_HEIGHT}
           onClick={handleCanvasClick}
           className="game-canvas"
         />
@@ -570,8 +570,10 @@ function App() {
             <div className="start-instruction">Click to start</div>
           </div>
         )}
-        <canvas 
+        <canvas
           ref={minimapCanvasRef}
+          width={CANVAS_WIDTH}
+          height={CANVAS_HEIGHT}
           className="minimap-canvas"
           style={{ bottom: `${layout.minimapBottom}px` }}
         />


### PR DESCRIPTION
## Summary
- Reference `CANVAS_WIDTH` and `CANVAS_HEIGHT` for both canvas elements to remove hardcoded dimensions.

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1eb9dc554832a8f90ee3775f31112