### PR TITLE
Use ref for play area layout updates

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,6 +11,7 @@ import './App.css';
 function App() {
   const canvasRef = useRef(null);
   const minimapCanvasRef = useRef(null);
+  const playAreaRef = useRef(null);
   const shipRef = useRef(new Ship(WORLD_WIDTH / 2, WORLD_HEIGHT / 2));
   const cameraRef = useRef(new Camera());
   const asteroidsRef = useRef([]);
@@ -488,7 +489,7 @@ function App() {
       }
       
       // Apply styles to play area
-      const playArea = document.querySelector('.play-area');
+      const playArea = playAreaRef.current;
       if (playArea) {
         playArea.style.left = `${playX}px`;
         playArea.style.top = `${playY}px`;
@@ -556,7 +557,7 @@ function App() {
 
   return (
     <div className="app">
-      <div className="play-area">
+      <div className="play-area" ref={playAreaRef}>
         <canvas 
           ref={canvasRef} 
           width={1200} 


### PR DESCRIPTION
## Summary
- attach playAreaRef to the play area div
- rely on playAreaRef instead of querySelector in layout calculations

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1eba78f08832aa94caa5723592fa8